### PR TITLE
Remove Ember 2.1 deprecation warning

### DIFF
--- a/app/initializers/storage-service.js
+++ b/app/initializers/storage-service.js
@@ -1,4 +1,5 @@
-export function initialize(container, application) {
+export function initialize() {
+  let application = arguments[1] || arguments[0];
   application.inject('route', 'storage', 'service:storage');
   application.inject('component', 'storage', 'service:storage');
 }

--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "ember-storage",
   "dependencies": {
-    "ember": "1.13.3",
+    "ember": "1.13.5",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.1",
+    "ember-qunit": "0.4.2",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.1",


### PR DESCRIPTION
Updates the initializer to remove the deprecation warning in Ember 2.1 caused by having two arguments (container, application) in the initialize function. This uses the backwards compatible safe method described in the deprecation pages (http://emberjs.com/deprecations/v2.x/#toc_initializer-arity)
