### PR TITLE
Use Headless Chrome instead of PhantomJS

### DIFF
--- a/addon/services/storage.js
+++ b/addon/services/storage.js
@@ -36,7 +36,7 @@ export default Ember.Service.extend({
 
     // an inelegant solution for behavior introduced in Ember 2.12.0-beta.1
     // fix introduced in Ember 2.14.0-beta.1
-    //https://github.com/emberjs/ember.js/commit/652adeee2d34c0ae1855612b1d26916eb7c3e40a#diff-83aef7046279fbc5512d665c03bff129
+    // https://github.com/emberjs/ember.js/commit/652adeee2d34c0ae1855612b1d26916eb7c3e40a
     if (k.includes('NAME_KEY') || k.includes('OWNER')){
       return;
     }

--- a/addon/services/storage.js
+++ b/addon/services/storage.js
@@ -34,6 +34,13 @@ export default Ember.Service.extend({
     let key = this._prefix(k),
         type = this.get('type');
 
+    // an inelegant solution for behavior introduced in Ember 2.12.0-beta.1
+    // fix introduced in Ember 2.14.0-beta.1
+    //https://github.com/emberjs/ember.js/commit/652adeee2d34c0ae1855612b1d26916eb7c3e40a#diff-83aef7046279fbc5512d665c03bff129
+    if (k.includes('NAME_KEY') || k.includes('OWNER')){
+      return;
+    }
+
     if(Ember.isNone(value)) {
       delete storage[type][key];
     } else {

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-qunit": "0.4.2",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.1",
+    "jquery": "~1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1"
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
     "ember-try": "0.0.6",
-    "phantomjs": "^1.9.17"
+    "phantomjs": "~1.9.17"
   },
   "keywords": [
     "ember-addon",

--- a/testem.json
+++ b/testem.json
@@ -3,10 +3,12 @@
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [
-    "PhantomJS"
+    "Chrome"
   ],
   "launch_in_dev": [
-    "PhantomJS",
     "Chrome"
-  ]
+  ],
+  "browser_args": {
+    "Chrome": ["--headless", "--disable-gpu", "--remote-debugging-port=9222"]
+  }
 }


### PR DESCRIPTION
Switch from PhantomJS to headless Chrome. This should fix the nondescript Travis CI build errors.